### PR TITLE
Bump actions version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Test
         id: test
         uses: ./


### PR DESCRIPTION
The current version was giving warnings in our workflow. I don't believe there's any serious issue with just bumping the version here.

<img width="1720" alt="Screenshot 2024-05-30 at 11 42 38" src="https://github.com/RedCrafter07/release-notes-action/assets/594614/f5d75bf2-0d39-4731-b697-13f10c596450">
